### PR TITLE
fix: Update Firebase hosting public paths to relative paths

### DIFF
--- a/firebase-dev/firebase.json
+++ b/firebase-dev/firebase.json
@@ -10,7 +10,7 @@
     "indexes": "firestore.indexes.json"
   },
   "hosting": {
-    "public": "/Users/keisukeshimizu/Development/DockerProject/haircut-reservation/frontend/.output/public",
+    "public": "../frontend/.output/public",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "headers": [
       {

--- a/firebase-prod/firebase.json
+++ b/firebase-prod/firebase.json
@@ -10,7 +10,7 @@
     "indexes": "firestore.indexes.json"
   },
   "hosting": {
-    "public": "../frontend/dist",
+    "public": "../frontend/.output/public",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {


### PR DESCRIPTION
- Change firebase-dev/firebase.json public path from absolute to relative
- Change firebase-prod/firebase.json public path to use .output/public
- Fix GitHub Actions deployment error: Directory does not exist
- Ensure consistent build output directory usage across environments